### PR TITLE
Use server-assigned nickname

### DIFF
--- a/handlers.lua
+++ b/handlers.lua
@@ -10,8 +10,9 @@ handlers["PING"] = function(o, prefix, query)
 	o:send("PONG :%s", query)
 end
 
-handlers["001"] = function(o)
+handlers["001"] = function(o, prefix, me)
 	o.authed = true
+	o.nick = me
 end
 
 handlers["PRIVMSG"] = function(o, prefix, channel, message)


### PR DESCRIPTION
This is needed if the server silently assigns a different nickname (e.g. ZNC servers). Otherwise LuaIRC crashes while joining a channel.
