### PR TITLE
A few changes...

### DIFF
--- a/asyncoperations.lua
+++ b/asyncoperations.lua
@@ -10,6 +10,8 @@ function meta:send(msg, ...)
 	if select("#", ...) > 0 then
 		msg = msg:format(...)
 	end
+	self:invoke("OnSend", msg)
+
 	local bytes, err = self.socket:send(msg .. "\r\n")
 
 	if not bytes and err ~= "timeout" and err ~= "wantwrite" then

--- a/asyncoperations.lua
+++ b/asyncoperations.lua
@@ -1,12 +1,16 @@
 local table = table
 local assert = assert
+local select = select
 
 module "irc"
 
 local meta = _META
 
-function meta:send(fmt, ...)
-	local bytes, err = self.socket:send(fmt:format(...) .. "\r\n")
+function meta:send(msg, ...)
+	if select("#", ...) > 0 then
+		msg = msg:format(...)
+	end
+	local bytes, err = self.socket:send(msg .. "\r\n")
 
 	if not bytes and err ~= "timeout" and err ~= "wantwrite" then
 		self:invoke("OnDisconnect", err, true)

--- a/doc/irc.luadoc
+++ b/doc/irc.luadoc
@@ -125,6 +125,7 @@ function irc:shutdown()
 
 --- List of hooks you can use with irc:hook. The parameter list describes the parameters passed to the callback function.
 -- <ul>
+-- <li><code>PreRegister(connection)</code>Useful for CAP commands and SASL.</li>
 -- <li><code>OnRaw(line) - (any non false/nil return value assumes line handled and will not be further processed)</code></li>
 -- <li><code>OnDisconnect(message, errorOccurred)</code></li>
 -- <li><code>OnChat(user, channel, message)</code></li>

--- a/doc/irc.luadoc
+++ b/doc/irc.luadoc
@@ -127,6 +127,7 @@ function irc:shutdown()
 -- <ul>
 -- <li><code>PreRegister(connection)</code>Useful for CAP commands and SASL.</li>
 -- <li><code>OnRaw(line) - (any non false/nil return value assumes line handled and will not be further processed)</code></li>
+-- <li><code>OnSend(line)</code></li>
 -- <li><code>OnDisconnect(message, errorOccurred)</code></li>
 -- <li><code>OnChat(user, channel, message)</code></li>
 -- <li><code>OnNotice(user, channel, message)</code></li>

--- a/doc/irc.luadoc
+++ b/doc/irc.luadoc
@@ -71,9 +71,9 @@ function irc:whois(nick)
 function irc:topic(channel)
 
 --- Send a raw line of IRC to the server.
--- @param fmt Line to be sent, excluding newline characters.
--- @param ... Format parameters for <code>fmt</code>, with <code>string.format</code> semantics.
-function irc:send(fmt, ...)
+-- @param msg Line to be sent, excluding newline characters.
+-- @param ... Format parameters for <code>msg</code>, with <code>string.format</code> semantics. [optional]
+function irc:send(msg, ...)
 
 --- Send a message to a channel or user.
 -- @param target Nick or channel to send to.

--- a/doc/irc.luadoc
+++ b/doc/irc.luadoc
@@ -154,7 +154,7 @@ function irc:shutdown()
 -- <li><code>username</code> - User username.</li>
 -- <li><code>host</code> - User hostname.</li>
 -- <li><code>realname</code> - User real name.</li>
--- <li><code>access</code> - User access, available in channel-oriented callbacks. Can be '+', '@', and others, depending on the server.</li>
+-- <li><code>access</code> - User access, available in channel-oriented callbacks. A table containing the boolean fields 'op', 'halfop', and 'voice'.</li>
 -- </ul>
 -- Apart from <code>nick</code>, fields may be missing. To fill them in, enable user tracking and use irc:whois.
 -- @name User

--- a/doc/irc.luadoc
+++ b/doc/irc.luadoc
@@ -141,7 +141,7 @@ function irc:shutdown()
 -- <li><code>OnKick(channel, nick, kicker, reason)</code>* (kicker is a <code>user</code> table)</li>
 -- <li><code>OnUserMode(modes)</code></li>
 -- <li><code>OnChannelMode(user, channel, modes)</code></li>
--- <li><code>OnModeChange(user, target, modes)</code>*</li>
+-- <li><code>OnModeChange(user, target, modes, ...)</code>* ('...' contains mode options such as banmasks)</li>
 -- </ul>
 -- * Event also invoked for yourself.
 -- † Channel passed only when user tracking is enabled

--- a/handlers.lua
+++ b/handlers.lua
@@ -130,8 +130,8 @@ handlers["324"] = function(o, prefix, user, channel, modes)
 	o:invoke("OnChannelMode", channel, modes)
 end
 
-handlers["MODE"] = function(o, prefix, target, modes)
-	o:invoke("OnModeChange", parsePrefix(prefix), target, modes)
+handlers["MODE"] = function(o, prefix, target, modes, ...)
+	o:invoke("OnModeChange", parsePrefix(prefix), target, modes, ...)
 end
 
 handlers["ERROR"] = function(o, prefix, message)

--- a/handlers.lua
+++ b/handlers.lua
@@ -1,6 +1,7 @@
 local pairs = pairs
 local error = error
 local tonumber = tonumber
+local table = table
 
 module "irc"
 
@@ -83,7 +84,7 @@ handlers["353"] = function(o, prefix, me, chanType, channel, names)
 		local users = o.channels[channel].users
 		for nick in names:gmatch("(%S+)") do
 			local access, name = parseNick(nick)
-			users[name] = {type = access}
+			users[name] = {access = access}
 		end
 	end
 end
@@ -131,6 +132,24 @@ handlers["324"] = function(o, prefix, user, channel, modes)
 end
 
 handlers["MODE"] = function(o, prefix, target, modes, ...)
+	if o.track_users and target ~= o.nick then
+		local add = true
+		local optList = {...}
+		for c in modes:gmatch(".") do
+			if     c == "+" then add = true
+			elseif c == "-" then add = false
+			elseif c == "o" then
+				local user = table.remove(optList, 1)
+				o.channels[target].users[user].access.op = add
+			elseif c == "h" then
+				local user = table.remove(optList, 1)
+				o.channels[target].users[user].access.halfop = add
+			elseif c == "v" then
+				local user = table.remove(optList, 1)
+				o.channels[target].users[user].access.voice = add
+			end
+		end
+	end
 	o:invoke("OnModeChange", parsePrefix(prefix), target, modes, ...)
 end
 

--- a/init.lua
+++ b/init.lua
@@ -116,6 +116,9 @@ function meta_preconnect:connect(_host, _port)
 
 	self.socket = s
 	setmetatable(self, meta)
+	
+	self:invoke("PreRegister", self)
+	self:send("CAP END")
 
 	if password then
 		self:send("PASS %s", password)

--- a/init.lua
+++ b/init.lua
@@ -26,7 +26,7 @@ function meta_preconnect.__index(o, k)
 	local v = rawget(meta_preconnect, k)
 
 	if not v and meta[k] then
-		error("field '"..k.."' is not accessible before connecting", 2)
+		error(("field '%s' is not accessible before connecting"):format(k), 2)
 	end
 	return v
 end

--- a/init.lua
+++ b/init.lua
@@ -116,7 +116,9 @@ function meta_preconnect:connect(_host, _port)
 
 	self.socket = s
 	setmetatable(self, meta)
-	
+
+	self:send("CAP REQ multi-prefix")
+
 	self:invoke("PreRegister", self)
 	self:send("CAP END")
 

--- a/util.lua
+++ b/util.lua
@@ -48,15 +48,28 @@ function parse(line)
 end
 
 function parseNick(nick)
-	return nick:match("^([%+@]?)(.+)$")
+	local access, name = nick:match("^([%+@]*)(.+)$")
+	return parseAccess(access or ""), name
 end
 
 function parsePrefix(prefix)
 	local user = {}
 	if prefix then
-		user.access, user.nick, user.username, user.host = prefix:match("^([%+@]?)(.+)!(.+)@(.+)$")
+		user.access, user.nick, user.username, user.host = prefix:match("^([%+@]*)(.+)!(.+)@(.+)$")
 	end
+	user.access = parseAccess(user.access or "")
 	return user
+end
+
+function parseAccess(accessString)
+	local access = {op = false, halfop = false, voice = false}
+	for c in accessString:gmatch(".") do
+		if     c == "@" then access.op = true
+		elseif c == "%" then access.halfop = true
+		elseif c == "+" then access.voice = true
+		end
+	end
+	return access
 end
 
 --mIRC markup scheme (de-facto standard)


### PR DESCRIPTION
Send mode options to the OnModeChange hook. (For modes that use options like +bieqfovhj)
Add OnSend hook. (Logging)
Interpret format codes literally if there aren't any formating arguments.  (Don't have to escape messages to send())
Add PreRegister hook. (Allows for CAP commands and SASL)
Track user access changes and request multi-prefix. (This also changes the format of user.access)
