### PR TITLE
Pass the connection to hooks

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -66,8 +66,8 @@ meta_preconnect.unhook = meta.unhook
 function meta:invoke(name, ...)
 	local hooks = self.hooks[name]
 	if hooks then
-		for id,f in pairs(hooks) do
-			if f(...) then
+		for id, f in pairs(hooks) do
+			if f(self, ...) then
 				return true
 			end
 		end


### PR DESCRIPTION
Without this you cannot tell which connection has invoked the hook and cannot respond to the correct connection. You have to store the connection as a global variable and can only have one at a time or need separate hooks. Unfortunately this breaks the current API, but shouldn't be too hard to update, eg:

``` lua
function bot.hooks.oldDebug(line)
    print(bot.conn.nick, line)
end

function bot.hooks:newDebug(line)
    print(self.nick, line)
end
```
