### PR TITLE
Sleep between thoughts when connecting to avoid eating CPU

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -137,6 +137,7 @@ function meta_preconnect:connect(_host, _port)
 
 	repeat
 		self:think()
+		socket.select(nil, nil, 0.1) -- Sleep so that we don't eat CPU
 	until self.authed
 end
 


### PR DESCRIPTION
This uses socket.select for a portable sleep, as described at http://lua-users.org/wiki/SleepFunction
