### PR TITLE
Allow hooking to any IRC command

### DIFF
--- a/doc/irc.luadoc
+++ b/doc/irc.luadoc
@@ -142,6 +142,7 @@ function irc:shutdown()
 -- <li><code>OnUserMode(modes)</code></li>
 -- <li><code>OnChannelMode(user, channel, modes)</code></li>
 -- <li><code>OnModeChange(user, target, modes, ...)</code>* ('...' contains mode options such as banmasks)</li>
+-- <li><code>DoX(user, ...)</code>'X' is any IRC command or numeric with the first letter capitalized (eg, DoPing and Do001)</li>
 -- </ul>
 -- * Event also invoked for yourself.
 -- † Channel passed only when user tracking is enabled

--- a/handlers.lua
+++ b/handlers.lua
@@ -7,25 +7,24 @@ module "irc"
 
 handlers = {}
 
-handlers["PING"] = function(o, prefix, query)
+handlers["PING"] = function(o, user, query)
 	o:send("PONG :%s", query)
 end
 
-handlers["001"] = function(o, prefix, me)
+handlers["001"] = function(o, user, me)
 	o.authed = true
 	o.nick = me
 end
 
-handlers["PRIVMSG"] = function(o, prefix, channel, message)
-	o:invoke("OnChat", parsePrefix(prefix), channel, message)
+handlers["PRIVMSG"] = function(o, user, channel, message)
+	o:invoke("OnChat", user, channel, message)
 end
 
-handlers["NOTICE"] = function(o, prefix, channel, message)
-	o:invoke("OnNotice", parsePrefix(prefix), channel, message)
+handlers["NOTICE"] = function(o, user, channel, message)
+	o:invoke("OnNotice", user, channel, message)
 end
 
-handlers["JOIN"] = function(o, prefix, channel)
-	local user = parsePrefix(prefix)
+handlers["JOIN"] = function(o, user, channel)
 	if o.track_users then
 		if user.nick == o.nick then
 			o.channels[channel] = {users = {}}
@@ -37,8 +36,7 @@ handlers["JOIN"] = function(o, prefix, channel)
 	o:invoke("OnJoin", user, channel)
 end
 
-handlers["PART"] = function(o, prefix, channel, reason)
-	local user = parsePrefix(prefix)
+handlers["PART"] = function(o, user, channel, reason)
 	if o.track_users then
 		if user.nick == o.nick then
 			o.channels[channel] = nil
@@ -49,8 +47,7 @@ handlers["PART"] = function(o, prefix, channel, reason)
 	o:invoke("OnPart", user, channel, reason)
 end
 
-handlers["QUIT"] = function(o, prefix, msg)
-	local user = parsePrefix(prefix)
+handlers["QUIT"] = function(o, user, msg)
 	if o.track_users then
 		for channel, v in pairs(o.channels) do
 			v.users[user.nick] = nil
@@ -59,8 +56,7 @@ handlers["QUIT"] = function(o, prefix, msg)
 	o:invoke("OnQuit", user, msg)
 end
 
-handlers["NICK"] = function(o, prefix, newnick)
-	local user = parsePrefix(prefix)
+handlers["NICK"] = function(o, user, newnick)
 	if o.track_users then
 		for channel, v in pairs(o.channels) do
 			local users = v.users
@@ -79,7 +75,7 @@ handlers["NICK"] = function(o, prefix, newnick)
 	end
 end
 
-local function needNewNick(o, prefix, target, badnick)
+local function needNewNick(o, user, target, badnick)
 	local newnick = o.nickGenerator(badnick)
 	o:send("NICK %s", newnick)
 end
@@ -91,7 +87,7 @@ handlers["432"] = needNewNick
 handlers["433"] = needNewNick
 
 --NAMES list
-handlers["353"] = function(o, prefix, me, chanType, channel, names)
+handlers["353"] = function(o, user, me, chanType, channel, names)
 	if o.track_users then
 		o.channels[channel] = o.channels[channel] or {users = {}, type = chanType}
 
@@ -104,48 +100,48 @@ handlers["353"] = function(o, prefix, me, chanType, channel, names)
 end
 
 --end of NAMES
-handlers["366"] = function(o, prefix, me, channel, msg)
+handlers["366"] = function(o, user, me, channel, msg)
 	if o.track_users then
 		o:invoke("NameList", channel, msg)
 	end
 end
 
 --no topic
-handlers["331"] = function(o, prefix, me, channel)
+handlers["331"] = function(o, user, me, channel)
 	o:invoke("OnTopic", channel, nil)
 end
 
 --new topic
-handlers["TOPIC"] = function(o, prefix, channel, topic)
+handlers["TOPIC"] = function(o, user, channel, topic)
 	o:invoke("OnTopic", channel, topic)
 end
 
-handlers["332"] = function(o, prefix, me, channel, topic)
+handlers["332"] = function(o, user, me, channel, topic)
 	o:invoke("OnTopic", channel, topic)
 end
 
 --topic creation info
-handlers["333"] = function(o, prefix, me, channel, nick, time)
+handlers["333"] = function(o, user, me, channel, nick, time)
 	o:invoke("OnTopicInfo", channel, nick, tonumber(time))
 end
 
-handlers["KICK"] = function(o, prefix, channel, kicked, reason)
-	o:invoke("OnKick", channel, kicked, parsePrefix(prefix), reason)
+handlers["KICK"] = function(o, user, channel, kicked, reason)
+	o:invoke("OnKick", channel, kicked, user, reason)
 end
 
 --RPL_UMODEIS
 --To answer a query about a client's own mode, RPL_UMODEIS is sent back
-handlers["221"] = function(o, prefix, user, modes)
+handlers["221"] = function(o, user, user, modes)
 	o:invoke("OnUserMode", modes)
 end
 
 --RPL_CHANNELMODEIS
 --The result from common irc servers differs from that defined by the rfc
-handlers["324"] = function(o, prefix, user, channel, modes)
+handlers["324"] = function(o, user, user, channel, modes)
 	o:invoke("OnChannelMode", channel, modes)
 end
 
-handlers["MODE"] = function(o, prefix, target, modes, ...)
+handlers["MODE"] = function(o, user, target, modes, ...)
 	if o.track_users and target ~= o.nick then
 		local add = true
 		local optList = {...}
@@ -164,11 +160,12 @@ handlers["MODE"] = function(o, prefix, target, modes, ...)
 			end
 		end
 	end
-	o:invoke("OnModeChange", parsePrefix(prefix), target, modes, ...)
+	o:invoke("OnModeChange", user, target, modes, ...)
 end
 
-handlers["ERROR"] = function(o, prefix, message)
+handlers["ERROR"] = function(o, user, message)
 	o:invoke("OnDisconnect", message, true)
 	o:shutdown()
 	error(message, 3)
 end
+

--- a/init.lua
+++ b/init.lua
@@ -182,10 +182,12 @@ end
 local handlers = handlers
 
 function meta:handle(prefix, cmd, params)
+	local user = parsePrefix(prefix)
 	local handler = handlers[cmd]
 	if handler then
-		return handler(self, prefix, unpack(params))
+		handler(self, user, unpack(params))
 	end
+	self:invoke("Do"..capitalize(cmd), user, unpack(params))
 end
 
 local whoisHandlers = {

--- a/util.lua
+++ b/util.lua
@@ -134,3 +134,9 @@ function defaultNickGenerator(nick)
 	return nick
 end
 
+function capitalize(text)
+  -- Converts first character to upercase and the rest to lowercase.
+  -- "PING" -> "Ping" | "hello" -> "Hello" | "123" -> "123"
+  return text:sub(1, 1):upper()..text:sub(2):lower()
+end
+


### PR DESCRIPTION
I also moved the `parsePrefix(prefix)` call into `meta:handle` so that it isn't called twice.
