### PR TITLE
Don't depend on module path being 'irc'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -17,9 +17,11 @@ local meta = {}
 meta.__index = meta
 _META = meta
 
-require "irc.util"
-require "irc.asyncoperations"
-require "irc.handlers"
+local path = ({...})[1]:gsub("[%.\\/]init$", "") .. '.'
+
+require(path .. "util")
+require(path .. "asyncoperations")
+require(path .. "handlers")
 
 local meta_preconnect = {}
 function meta_preconnect.__index(o, k)


### PR DESCRIPTION
This allows users to put the LuaIRC module wherever they want.
