### PR TITLE
"No protocols available" on Ubuntu 20.04

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -106,7 +106,7 @@ function meta_preconnect:connect(_host, _port)
 		if type(secure) == "table" then
 			params = secure
 		else
-			params = {mode = "client", protocol = "tlsv1"}
+			params = {mode = "client", protocol = "any"}
 		end
 
 		s = ssl.wrap(s, params)


### PR DESCRIPTION
I received the above error message using LuaIRC with the Minetest IRC mod. Because I am only able to configure `secure` as a boolean `true` and not with a table specifying `protocol` I have come up with this small change to LuaIRC which I think benefits many users and leaves no users disadvantaged.

`tlsv1` and `tlsv1_1` are insecure, deprecated and no longer available on Ubuntu as of 20.04 so hardcoding `tlsv1` as a default is a bad idea. This pull request fixes the problem by not specifying the protocol version. LuaIRC will now use the highest TLS version available. Using `protocol = "any"` is also used in the client example for Luasec at https://github.com/brunoos/luasec/wiki . Luasec itself changed from "tlsv1" to "any" in version 0.6 as the default for https connections.

To diagnose the problem, I used openssl to check what protocols were available. TLSv1 and TLSv1.1 worked on MacOS 10.14 but not on Ubuntu 20.04 as can be seen by the failure of these commands on Ubuntu.

    openssl s_client -connect chat.freenode.net:6697 -tls1
    openssl s_client -connect chat.freenode.net:6697 -tls1_1

TLSv1.2 and TLSv1.3 worked on both MacOS 10.14 and Ubuntu 20.04 as can be seen by the success of these commands.

    openssl s_client -connect chat.freenode.net:6697 -tls1_2
    openssl s_client -connect chat.freenode.net:6697 -tls1_3

Deprecating TLSv1 and TLSv1.1 is recommended by this IETF RFC https://datatracker.ietf.org/doc/draft-ietf-tls-oldversions-deprecate/ . The RFC also recommends that clients specify their highest supported protocol.